### PR TITLE
Adding support for RKE2 clusters and detecting custom cluster domain

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -1,7 +1,9 @@
 package common
 
 const (
-	K8sClientBurst   = 50
-	K8sClientqps     = 25
-	K8sClientTimeout = 10
+	// Reduced QPS and burst to avoid rate limiting
+	K8sClientBurst = 20
+	K8sClientqps   = 10
+	// Increased timeout to allow for DNS resolution tests
+	K8sClientTimeout = 120
 )

--- a/internal/detect/dns.go
+++ b/internal/detect/dns.go
@@ -13,28 +13,63 @@ import (
 )
 
 func DetectDNSImplementation(clients *common.Clients, clusterDNSConfig *common.ClusterDNSConfig) error {
-
 	log.Info("Attempting to detect K8s internal DNS Service")
 	found, err := DetectCoreDNSByService(clients, clusterDNSConfig)
-
-	if found {
-		log.Info("DNS Service Found")
-	}
-
 	if err != nil {
-		log.Errorf("Error detecting CoreDNS by ConfigMap: %v", err)
+		return fmt.Errorf("error detecting CoreDNS service: %v", err)
 	}
+	if !found {
+		return errors.New("no DNS service found in the cluster")
+	}
+	log.Info("DNS Service Found")
 
 	log.Info("Attempting to acquire DNS corefile")
 	err = GetDNSCoreFile(clients, clusterDNSConfig)
 	if err != nil {
-		log.Errorf("Error acquiring Corefile: %v", err)
+		return fmt.Errorf("error acquiring Corefile: %v", err)
+	}
+
+	if clusterDNSConfig.DNSServiceDomain == "" {
+		return errors.New("cluster domain not found in CoreDNS configuration")
 	}
 
 	return nil
 }
 func DetectCoreDNSByService(clients *common.Clients, clusterDNSConfig *common.ClusterDNSConfig) (bool, error) {
+	// First try kube-system namespace
+	kubeSystemServices := []string{"kube-dns", "coredns", "dns-default"}
+	log.Debug("Checking kube-system namespace for DNS services")
+	for _, serviceName := range kubeSystemServices {
+		log.Debugf("Looking for DNS service: %s in kube-system namespace", serviceName)
+		service, err := clients.KubeClient.CoreV1().Services("kube-system").Get(context.TODO(), serviceName, metav1.GetOptions{})
+		if err == nil {
+			log.Infof("Found DNS service %s in kube-system namespace", serviceName)
+			clusterDNSConfig.DNSServiceEndpointIP = service.Spec.ClusterIP
+			clusterDNSConfig.DNSServiceServiceName = service.Name
+			clusterDNSConfig.DNSServiceNamespace = service.Namespace
+			clusterDNSConfig.DNSLabelSelector = mapToString(service.Spec.Selector)
+			return true, nil
+		}
+	}
 
+	// If not found in kube-system, try openshift-dns namespace
+	openshiftServices := []string{"dns-default"}
+	log.Debug("Checking openshift-dns namespace for DNS services")
+	for _, serviceName := range openshiftServices {
+		log.Debugf("Looking for DNS service: %s in openshift-dns namespace", serviceName)
+		service, err := clients.KubeClient.CoreV1().Services("openshift-dns").Get(context.TODO(), serviceName, metav1.GetOptions{})
+		if err == nil {
+			log.Infof("Found DNS service %s in openshift-dns namespace", serviceName)
+			clusterDNSConfig.DNSServiceEndpointIP = service.Spec.ClusterIP
+			clusterDNSConfig.DNSServiceServiceName = service.Name
+			clusterDNSConfig.DNSServiceNamespace = service.Namespace
+			clusterDNSConfig.DNSLabelSelector = mapToString(service.Spec.Selector)
+			return true, nil
+		}
+	}
+
+	// If still not found, try listing all services as a fallback
+	log.Debug("DNS service not found in standard namespaces, searching all namespaces")
 	serviceList, err := clients.KubeClient.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return false, errors.New("unable to list services")
@@ -46,41 +81,99 @@ func DetectCoreDNSByService(clients *common.Clients, clusterDNSConfig *common.Cl
 		}
 
 		for _, port := range service.Spec.Ports {
+			// First check if it's port 53 and has "dns" in the name
 			if port.Port == 53 && strings.Contains(strings.ToLower(port.Name), "dns") {
 				clusterDNSConfig.DNSServiceEndpointIP = service.Spec.ClusterIP
 				clusterDNSConfig.DNSServiceServiceName = service.Name
 				clusterDNSConfig.DNSServiceNamespace = service.Namespace
 				clusterDNSConfig.DNSLabelSelector = mapToString(service.Spec.Selector)
+				log.Debugf("Found DNS service with DNS port name: %s in namespace %s", service.Name, service.Namespace)
+				return true, nil
+			}
+			// If not found, check if it's just port 53 (some distributions might not include "dns" in port name)
+			if port.Port == 53 {
+				clusterDNSConfig.DNSServiceEndpointIP = service.Spec.ClusterIP
+				clusterDNSConfig.DNSServiceServiceName = service.Name
+				clusterDNSConfig.DNSServiceNamespace = service.Namespace
+				clusterDNSConfig.DNSLabelSelector = mapToString(service.Spec.Selector)
+				log.Debugf("Found DNS service: %s in namespace %s", service.Name, service.Namespace)
 				return true, nil
 			}
 		}
 	}
 
-	return false, nil
+	return false, errors.New("no DNS service found in kube-system, openshift-dns, or any other namespace")
 }
 
 func GetDNSCoreFile(clients *common.Clients, clusterDNSConfig *common.ClusterDNSConfig) error {
+	// Try to get CoreDNS configmap from the same namespace as the DNS service
+	if clusterDNSConfig.DNSServiceNamespace != "" {
+		log.Debugf("Looking for CoreDNS configmap in DNS service namespace: %s", clusterDNSConfig.DNSServiceNamespace)
+		configMap, err := clients.KubeClient.CoreV1().ConfigMaps(clusterDNSConfig.DNSServiceNamespace).Get(context.TODO(), "coredns", metav1.GetOptions{})
+		if err == nil {
+			log.Debug("Found CoreDNS configmap in DNS service namespace")
+			// Try both cases for Corefile
+			for key, value := range configMap.Data {
+				if strings.ToLower(key) == "corefile" {
+					log.Debugf("Found Corefile key: %s", key)
+					clusterDomain, err := extractClusterDomain(value)
+					if err == nil {
+						log.Infof("Successfully extracted cluster domain: %s", clusterDomain)
+						clusterDNSConfig.DNSServiceDomain = clusterDomain
+						return nil
+					}
+					log.Debugf("Failed to extract cluster domain: %v", err)
+				}
+			}
+		} else {
+			log.Debugf("Error getting CoreDNS configmap from DNS service namespace: %v", err)
+		}
+	}
 
+	// If not found in DNS service namespace, try kube-system
+	log.Debug("Looking for CoreDNS configmap in kube-system namespace")
+	configMap, err := clients.KubeClient.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "coredns", metav1.GetOptions{})
+	if err == nil {
+		log.Debug("Found CoreDNS configmap in kube-system namespace")
+		for key, value := range configMap.Data {
+			if strings.ToLower(key) == "corefile" {
+				log.Debugf("Found Corefile key: %s", key)
+				clusterDomain, err := extractClusterDomain(value)
+				if err == nil {
+					log.Infof("Successfully extracted cluster domain: %s", clusterDomain)
+					clusterDNSConfig.DNSServiceDomain = clusterDomain
+					return nil
+				}
+				log.Debugf("Failed to extract cluster domain: %v", err)
+			}
+		}
+	} else {
+		log.Debugf("Error getting CoreDNS configmap from kube-system namespace: %v", err)
+	}
+
+	// If still not found, try listing all configmaps as a fallback
+	log.Debug("CoreDNS configmap not found in standard namespaces, searching all namespaces")
 	configMaps, err := clients.KubeClient.CoreV1().ConfigMaps("").List(context.TODO(), metav1.ListOptions{})
-
 	if err != nil {
 		return errors.New("unable to list configmaps")
 	}
 
 	for _, configMap := range configMaps.Items {
-		if corefile, exists := configMap.Data["Corefile"]; exists {
-			clusterDomain, err := extractClusterDomain(corefile)
-			if err != nil {
-				return err
+		for key, value := range configMap.Data {
+			if strings.ToLower(key) == "corefile" {
+				log.Debugf("Found potential Corefile in namespace %s", configMap.Namespace)
+				clusterDomain, err := extractClusterDomain(value)
+				if err == nil {
+					log.Infof("Successfully extracted cluster domain from namespace %s: %s", configMap.Namespace, clusterDomain)
+					clusterDNSConfig.DNSServiceDomain = clusterDomain
+					return nil
+				}
+				log.Debugf("Failed to extract cluster domain from namespace %s: %v", configMap.Namespace, err)
 			}
-			clusterDNSConfig.DNSServiceDomain = clusterDomain
-			return nil
 		}
-
 	}
 
-	log.Info("Corefile not found")
-	return nil
+	return errors.New("Corefile not found in any namespace")
 }
 
 func extractClusterDomain(corefile string) (string, error) {


### PR DESCRIPTION
I got it working on my RKE2 cluster, which includes ARM nodes and a custom cluster domain `a1-ops-prd.local` vs. `cluster.local`.

I also did some cleanup around logging.

```
INFO[0001] default namespace already exists, will not create 
INFO[0001] Detecting DNS Service                        
INFO[0001] Attempting to detect K8s internal DNS Service 
INFO[0001] DNS Service Found                            
INFO[0001] Attempting to acquire DNS corefile           
INFO[0002] Successfully extracted cluster domain from namespace kube-system: a1-ops-prd.local 
INFO[0002] Running Internal and External DNS Tests      
INFO[0002] Checking active DNS Endpoint                 
INFO[0002] Checking associated endpoint Pods            
INFO[0002] Checking internal DNS resolution, please wait 
                                                             DNS Networking Tests (Internal)                                                            
 FROM (NODE)    FROM (POD)      TO (NODE)   TO (POD)                                    INTRA/INTER  STATUS     DOMAIN                                  
 a0ublokip01    dns-test-g84xn  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a0ublokip01    dns-test-mr6cf  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode01     dns-test-57bpq  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode01     dns-test-8phhr  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode02     dns-test-dm6p6  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode02     dns-test-2dbjp  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode03     dns-test-t5xl4  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1pinode03     dns-test-szp9g  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubofficep01  dns-test-zswlb  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubofficep01  dns-test-kjb86  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp01     dns-test-cn6q5  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp01     dns-test-9vmld  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp02     dns-test-ssx9n  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp02     dns-test-b8vqq  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp03     dns-test-qwsnc  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp03     dns-test-px5pl  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp04     dns-test-5nd5c  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  intra        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp04     dns-test-r52h7  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp05     dns-test-pv7bf  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  intra        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp05     dns-test-z8d8j  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp06     dns-test-5wvgp  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
 a1ubopsp06     dns-test-rvzmd  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  kubernetes.default.svc.a1-ops-prd.local 
INFO[0037] Checking external DNS resolution, please wait 
                                              DNS Networking Tests (External)                                              
 FROM (NODE)    FROM (POD)      TO (NODE)   TO (POD)                                    INTRA/INTER  STATUS     DOMAIN     
 a0ublokip01    dns-test-mk2px  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a0ublokip01    dns-test-297wt  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1pinode01     dns-test-l6q45  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1pinode01     dns-test-j8vlw  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1pinode02     dns-test-mnvqg  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1pinode02     dns-test-g8txw  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1pinode03     dns-test-j6tpn  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1pinode03     dns-test-hrskh  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubofficep01  dns-test-sms9v  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubofficep01  dns-test-snz2z  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubopsp01     dns-test-56wcz  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubopsp01     dns-test-ls684  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubopsp02     dns-test-cs7kj  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubopsp02     dns-test-9f6j8  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubopsp03     dns-test-8jvzt  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubopsp03     dns-test-hnjd4  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubopsp04     dns-test-q2d5m  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  intra        Succeeded  google.com 
 a1ubopsp04     dns-test-xkfpx  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
 a1ubopsp05     dns-test-6z27d  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubopsp05     dns-test-6v6gz  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  intra        Succeeded  google.com 
 a1ubopsp06     dns-test-w95xc  a1ubopsp04  rke2-coredns-rke2-coredns-7f47b5b8c6-7tx2j  inter        Succeeded  google.com 
 a1ubopsp06     dns-test-jmp5f  a1ubopsp05  rke2-coredns-rke2-coredns-7f47b5b8c6-t9wff  inter        Succeeded  google.com 
INFO[0067] Running Overlay Network Tests                
INFO[0067] Checking overlay network                     
                                           Overlay Networking Tests                                           
 FROM (NODE)  FROM (POD)                       TO (NODE)   TO (POD)                         STATUS   PROTOCOL 
 a1ubopsp01   overlay-network-testgccq8-cs48p  a1ubopsp05  overlay-network-testgccq8-n9vz7  Success  TCP 80   
 a1ubopsp01   overlay-network-testgccq8-cs48p  a1ubopsp03  overlay-network-testgccq8-79sfj  Success  TCP 80   
 a1ubopsp01   overlay-network-testgccq8-cs48p  a1ubopsp02  overlay-network-testgccq8-qfxbl  Success  TCP 80   
 a1ubopsp01   overlay-network-testgccq8-cs48p  a1ubopsp04  overlay-network-testgccq8-99vsh  Success  TCP 80   
 a1ubopsp02   overlay-network-testgccq8-qfxbl  a1ubopsp04  overlay-network-testgccq8-99vsh  Success  TCP 80   
 a1ubopsp02   overlay-network-testgccq8-qfxbl  a1ubopsp05  overlay-network-testgccq8-n9vz7  Success  TCP 80   
 a1ubopsp02   overlay-network-testgccq8-qfxbl  a1ubopsp01  overlay-network-testgccq8-cs48p  Success  TCP 80   
 a1ubopsp02   overlay-network-testgccq8-qfxbl  a1ubopsp03  overlay-network-testgccq8-79sfj  Success  TCP 80   
 a1ubopsp03   overlay-network-testgccq8-79sfj  a1ubopsp01  overlay-network-testgccq8-cs48p  Success  TCP 80   
 a1ubopsp03   overlay-network-testgccq8-79sfj  a1ubopsp02  overlay-network-testgccq8-qfxbl  Success  TCP 80   
 a1ubopsp03   overlay-network-testgccq8-79sfj  a1ubopsp04  overlay-network-testgccq8-99vsh  Success  TCP 80   
 a1ubopsp03   overlay-network-testgccq8-79sfj  a1ubopsp05  overlay-network-testgccq8-n9vz7  Success  TCP 80   
 a1ubopsp04   overlay-network-testgccq8-99vsh  a1ubopsp01  overlay-network-testgccq8-cs48p  Success  TCP 80   
 a1ubopsp04   overlay-network-testgccq8-99vsh  a1ubopsp05  overlay-network-testgccq8-n9vz7  Success  TCP 80   
 a1ubopsp04   overlay-network-testgccq8-99vsh  a1ubopsp02  overlay-network-testgccq8-qfxbl  Success  TCP 80   
 a1ubopsp04   overlay-network-testgccq8-99vsh  a1ubopsp03  overlay-network-testgccq8-79sfj  Success  TCP 80   
 a1ubopsp05   overlay-network-testgccq8-n9vz7  a1ubopsp01  overlay-network-testgccq8-cs48p  Success  TCP 80   
 a1ubopsp05   overlay-network-testgccq8-n9vz7  a1ubopsp04  overlay-network-testgccq8-99vsh  Success  TCP 80   
 a1ubopsp05   overlay-network-testgccq8-n9vz7  a1ubopsp02  overlay-network-testgccq8-qfxbl  Success  TCP 80   
 a1ubopsp05   overlay-network-testgccq8-n9vz7  a1ubopsp03  overlay-network-testgccq8-79sfj  Success  TCP 80   
INFO[0072] Checking NIC Attributes          
....
```